### PR TITLE
ci: bump the make parallelism to 4

### DIFF
--- a/ci/genericbuild.py
+++ b/ci/genericbuild.py
@@ -58,7 +58,7 @@ class GenericBuild(Base):
 
         # Make
         # AR: Maybe read from /proc for job count
-        cmd = [self.make_cmd, "-j2"]
+        cmd = [self.make_cmd, "-j4"]
         if self.use_fakeroot:
             cmd = ["fakeroot"] + cmd
         if self.make_params:

--- a/ci/generickernelbuild.py
+++ b/ci/generickernelbuild.py
@@ -58,7 +58,7 @@ class GenericKernelBuild(Base):
         # make
         self.log_info("Run make")
 
-        base_cmd = ["make", "-j2"]
+        base_cmd = ["make", "-j4"]
         if self.make_params:
             base_cmd += self.make_params
         self.log_dbg(f"GenericKernelBuild: Base Command: {base_cmd}")

--- a/ci/scanbuild.py
+++ b/ci/scanbuild.py
@@ -40,7 +40,7 @@ class ScanBuild(Base):
             self.add_failure_end_test(stderr)
 
         # Scan Build Make
-        cmd = ["scan-build", "make", "-j2"]
+        cmd = ["scan-build", "make", "-j4"]
         (ret, stdout, stderr) = cmd_run(cmd, cwd=self.ci_data.src_dir)
         if ret:
             self.log_err("Scan Build failed")


### PR DESCRIPTION
The standard GitHub-hosted runners, for public repositories have four CPUs [1]. Update the make invocations.

[1] https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

---

Should reduce the execution times - we are at 1-2 hours for each set.

Cc @tedd-an @Vudentz